### PR TITLE
31-update-version-constrains

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -24,3 +24,17 @@ jobs:
           user_email: 'github-actions@github.com'
           user_name: ${{ github.actor }}
           commit_message: ${{ github.event.head_commit.message }}
+      - name: Pushes to another repository
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          API_TOKEN_GITHUB: ${{ secrets.ARC_DOCS_API_TOKEN_GITHUB }}
+        with:
+          source-directory: 'static'
+          destination-github-username: 'sourcefuse'
+          destination-repository-name: 'arc-docs'
+          target-directory: 'docs/arc-iac-docs/modules/terraform-aws-refarch-tags/static'
+          user-email: 'github-actions@github.com'
+          user-name: ${{ github.actor }}
+          target-branch: main
+          commit-message: ${{ github.event.head_commit.message }}

--- a/.terraform-version
+++ b/.terraform-version
@@ -1,1 +1,1 @@
-latest-allowed
+latest

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Module Structure](./static/banner.png)
+
 # [terraform-aws-arc-tags](https://github.com/sourcefuse/terraform-aws-arc-tags)
 
 <a href="https://github.com/sourcefuse/terraform-aws-arc-tags/releases/latest"><img src="https://img.shields.io/github/release/sourcefuse/terraform-aws-arc-tags.svg?style=for-the-badge" alt="Latest Release"/></a> <a href="https://github.com/sourcefuse/terraform-aws-arc-tags/commits"><img src="https://img.shields.io/github/last-commit/sourcefuse/terraform-aws-arc-tags.svg?style=for-the-badge" alt="Last Updated"/></a> ![Terraform](https://img.shields.io/badge/terraform-%235835CC.svg?style=for-the-badge&logo=terraform&logoColor=white) ![GitHub Actions](https://img.shields.io/badge/github%20actions-%232671E5.svg?style=for-the-badge&logo=githubactions&logoColor=white)

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ This module is responsible for managing the tags we use at SourceFuse when creat
 ```hcl
 module "terraform-aws-arc-tags" {
   source      = "sourcefuse/arc-tags/aws"
-  version     = "1.2.4"
-  environment = var.environment
+  # version     = "x.x.x"  # we recommend pinning to a specific version
+  environment = "dev"
   project     = "Example"
 
   extra_tags = {
-    RepoName = "terraform-aws-refarch-ecs"
+    RepoName = "terraform-aws-arc-ecs"
     Example  = "true"
   }
 }
@@ -31,7 +31,7 @@ module "terraform-aws-arc-tags" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.4 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4, < 2.0.0 |
 
 ## Providers
 

--- a/provider.tf
+++ b/provider.tf
@@ -2,5 +2,5 @@
 ## defaults / versions
 ###########################################
 terraform {
-  required_version = "~> 1.4"
+  required_version = ">= 1.4, < 2.0.0"
 }


### PR DESCRIPTION
Changed required Terraform version from "~> 1.4" to ">= 1.4, < 2.0.0" for better compatibility. Updated `.terraform-version` file to specify "latest" instead of "latest-allowed". Adjusted README to recommend pinning module version and corrected example tags.

closes #31 